### PR TITLE
feat: extract shell profile setup into install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ if [ ! -d "$HOME/.ejb/dotfiles" ]; then
   echo "Created $HOME/.ejb/dotfiles"
 fi
 
-# add the following to .bashrc or equivalent
-echo 'if [ -f "$HOME/.ejb/dotfiles/.bash_ejb" ]; then' >> ~/.bashrc
-echo '  . "$HOME/.ejb/dotfiles/.bash_ejb"' >> ~/.bashrc
-echo 'fi' >> ~/.bashrc
+# run the install script, then open a new terminal for the changes to take effect
+$HOME/.ejb/dotfiles/install.sh
 ```
 
 ## Update

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  PROFILE="$HOME/.bash_profile"
+else
+  PROFILE="$HOME/.bashrc"
+fi
+
+if [ ! -f "$PROFILE" ]; then
+  touch "$PROFILE"
+fi
+
+if grep -q "dotfiles/.bash_ejb" "$PROFILE"; then
+  echo "Already installed. Nothing to do."
+else
+  {
+    echo 'if [ -f "$HOME/.ejb/dotfiles/.bash_ejb" ]; then'
+    echo '  . "$HOME/.ejb/dotfiles/.bash_ejb"'
+    echo 'fi'
+  } >> "$PROFILE"
+  echo "Added .bash_ejb to $PROFILE"
+  echo "Open a new terminal for the changes to take effect."
+fi


### PR DESCRIPTION
Move the .bashrc/.bash_profile setup out of README.md into a standalone, idempotent install.sh that detects macOS vs Linux and targets the right profile file.