### PR TITLE
Let docker test harness target a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ git reset --hard origin/master > /dev/null 2>&1
 ### Test
 
 ```bash
-./devbin/run
+./devbin/run                      # tests master
+./devbin/run some-branch-name     # tests a pushed branch/ref instead
 ```
 
 ### Snippets

--- a/devbin/run
+++ b/devbin/run
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+# Purpose: build and run the docker test harness, optionally cloning a
+#          specific branch/ref of the dotfiles repo (default: master)
 ./devbin/build
-docker run --rm -it ejb-dotfiles
+docker run --rm -it -e DOTFILES_REF="${1:-master}" ejb-dotfiles

--- a/src/docker/entry-point.sh
+++ b/src/docker/entry-point.sh
@@ -2,7 +2,7 @@
 # Purpose: provide a single place to trigger different types of
 #          tests (er. as root, as non-root user)
 mkdir ~/.ejb
-git clone https://github.com/evanjbowling/dotfiles.git ~/.ejb/dotfiles
+git clone -b "${DOTFILES_REF:-master}" https://github.com/evanjbowling/dotfiles.git ~/.ejb/dotfiles
 
 echo 'if [ -f "$HOME/.ejb/dotfiles/.bash_ejb" ]; then' >> ~/.bashrc
 echo '  . "$HOME/.ejb/dotfiles/.bash_ejb"' >> ~/.bashrc


### PR DESCRIPTION
## Summary
- `entry-point.sh` always cloned `master`, so there was no way to test an unmerged branch before opening/merging a PR
- `devbin/run` now accepts an optional branch arg (default `master`), passed through as the `DOTFILES_REF` env var, which `entry-point.sh` uses for the clone

## Test plan
- [x] `docker run --entrypoint bash -e DOTFILES_REF=feature/install-setup-scripts ejb-dotfiles -c '...'` confirmed it clones that branch (not master), runs `install.sh` successfully, and `devbin/diff-installed` reports everything up to date

## Note
This branch is independent of #11 and can be reviewed/merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)